### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.git
+src/log
+src/nse_cache
+src/config/config.yaml
+*.xml
+.env

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Plum-Island controller URL (required)
+PLUM_ISLAND=http://island:5000
+
+# Agent API key issued by Plum-Island (required)
+PLUM_AGENT_KEY=changeme
+
+# Force a specific external IP reported to the controller (optional)
+# Useful when the container cannot reach the internet for auto-detection.
+# PLUM_EXT_IP=1.2.3.4
+
+# Set to 1 to enable verbose / debug output (optional)
+# PLUM_VERBOSE=0
+
+# Note: PLUM_AGENT_KEY is passed as a CLI argument and will be visible in
+# process listings (ps aux). This matches the bare-metal agent behaviour.
+# Restrict access to the host accordingly.

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Plum-Island controller URL (required)
-PLUM_ISLAND=http://island:5000
+# When running alongside Plum-Island via the shared plum_net Docker network,
+# use the Island's compose service name as the hostname (default: webapp).
+PLUM_ISLAND=http://webapp:5000
 
 # Agent API key issued by Plum-Island (required)
 PLUM_AGENT_KEY=changeme

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        nmap \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src/ ./src/
+
+RUN mkdir -p src/config src/log src/nse_cache
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+WORKDIR /app/src
+
+VOLUME ["/app/src/config", "/app/src/log", "/app/src/nse_cache"]
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  plum-agent:
+    build: .
+    restart: unless-stopped
+    env_file: .env
+    cap_add:
+      - NET_RAW
+      - NET_ADMIN
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - plum_config:/app/src/config
+      - plum_log:/app/src/log
+      - plum_nse_cache:/app/src/nse_cache
+
+volumes:
+  plum_config:
+  plum_log:
+  plum_nse_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,14 @@ services:
       - plum_config:/app/src/config
       - plum_log:/app/src/log
       - plum_nse_cache:/app/src/nse_cache
+    networks:
+      - plum_net
 
 volumes:
   plum_config:
   plum_log:
   plum_nse_cache:
+
+networks:
+  plum_net:
+    external: true

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+CMD=(python agent.py -d)
+
+if [ -n "${PLUM_ISLAND}" ]; then
+    CMD+=(-island "${PLUM_ISLAND}")
+fi
+
+if [ -n "${PLUM_AGENT_KEY}" ]; then
+    CMD+=(-agentkey "${PLUM_AGENT_KEY}")
+fi
+
+if [ -n "${PLUM_EXT_IP}" ]; then
+    CMD+=(-ipext "${PLUM_EXT_IP}")
+fi
+
+if [ "${PLUM_VERBOSE:-0}" = "1" ]; then
+    CMD+=(-v)
+fi
+
+exec "${CMD[@]}"

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,37 @@ python agent.py -s -island *HOSTOFISLAND* -agentkey *XXXTHETOKENKEYXXXX*
 ### Execution
 python agent -d 
 
+## Docker
+
+### Quick start
+
+```bash
+cp .env.example .env          # fill in PLUM_ISLAND and PLUM_AGENT_KEY
+docker compose up -d
+```
+
+The container runs the agent in daemon mode. Three named volumes persist state across restarts:
+
+| Volume | Path inside container | Contents |
+|--------|-----------------------|----------|
+| `plum_config` | `/app/src/config` | Agent UUID and saved configuration |
+| `plum_log` | `/app/src/log` | `agent.log` |
+| `plum_nse_cache` | `/app/src/nse_cache` | Controller-managed NSE scripts |
+
+### Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `PLUM_ISLAND` | Yes | URL of the Plum-Island controller (e.g. `http://island:5000`) |
+| `PLUM_AGENT_KEY` | Yes | API key issued by Plum-Island |
+| `PLUM_EXT_IP` | No | Force the external IP reported to the controller (useful in air-gapped setups) |
+| `PLUM_VERBOSE` | No | Set to `1` to enable debug output |
+
+### Capabilities
+
+The container requests `NET_RAW` and `NET_ADMIN` so nmap can perform SYN scans.
+These capabilities are declared in `docker-compose.yml` and are required for proper operation.
+
 ### Help
 ```bash
 $ ./agent.py --help

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,46 @@ The container runs the agent in daemon mode. Three named volumes persist state a
 | `PLUM_EXT_IP` | No | Force the external IP reported to the controller (useful in air-gapped setups) |
 | `PLUM_VERBOSE` | No | Set to `1` to enable debug output |
 
+### Networking — connecting to Plum-Island
+
+Plum-Agent and Plum-Island run as separate Docker Compose stacks and are therefore on isolated networks by default. A shared external network is required so the agent container can reach the Island webapp.
+
+**One-time setup (run once on the host):**
+
+```bash
+docker network create plum_net
+```
+
+**Plum-Island** — add the network to its `docker-compose.yml`:
+
+```yaml
+services:
+  webapp:
+    networks:
+      - plum_net
+    # ... rest of service definition
+
+networks:
+  plum_net:
+    external: true
+```
+
+**Plum-Agent** — already configured in this repo's `docker-compose.yml`. Set `PLUM_ISLAND` to the Island's service name on the shared network:
+
+```bash
+PLUM_ISLAND=http://webapp:5000
+```
+
+Then restart both stacks:
+
+```bash
+# in Plum-Island directory
+docker compose up -d
+
+# in Plum-Agent directory
+docker compose up -d
+```
+
 ### Capabilities
 
 The container requests `NET_RAW` and `NET_ADMIN` so nmap can perform SYN scans.


### PR DESCRIPTION
## Summary

- **`Dockerfile`** — `python:3.13-slim` base with nmap installed; installs Python deps then copies `src/`; working directory is `/app/src` matching `THIS_DIR` in `agent.py`
- **`docker-entrypoint.sh`** — translates `PLUM_ISLAND`, `PLUM_AGENT_KEY`, `PLUM_EXT_IP`, and `PLUM_VERBOSE` env vars into the agent's CLI arguments and `exec`s the agent in daemon mode
- **`docker-compose.yml`** — daemon service with `NET_RAW` + `NET_ADMIN` capabilities (required for nmap SYN scanning), `no-new-privileges` security option, and named volumes for `config/`, `log/`, and `nse_cache/`
- **`.env.example`** — template listing all supported env vars with descriptions
- **`.dockerignore`** — excludes `.venv`, `__pycache__`, `.git`, `.env`, `src/config/config.yaml`, and scan output XML from the build context
- **`readme.md`** — Docker quick-start section with environment variable and volume reference tables
- **`src/utils/mutils.py`** — `get_version()` now catches `OSError` (superset of `FileNotFoundError`) in addition to `CalledProcessError`, so the agent starts cleanly when `git` is not installed (returns `"unknown"` instead of crashing)

## Design notes

- The agent UUID is persisted via the `plum_config` volume so each restart reuses the same bot identity on the Island.
- `PLUM_EXT_IP` maps to `-ipext` — useful when the container cannot reach external IP-detection services (air-gapped deployments).
- `git` is intentionally not installed in the image: `.git` is excluded by `.dockerignore` so version detection via git would always fail anyway; `get_version()` now gracefully returns `"unknown"` in that case.
- `PLUM_AGENT_KEY` is passed as a CLI argument (visible in `ps aux`), matching the existing bare-metal behaviour. The `.env.example` documents this limitation.

## Test plan

- [ ] `docker compose up -d` starts the container and it beacons to a running Plum-Island instance
- [ ] Restarting the container reuses the same agent UUID (verify via Island bot list)
- [ ] `PLUM_EXT_IP` overrides the reported external IP
- [ ] `PLUM_VERBOSE=1` produces debug output in `docker compose logs`
- [ ] `docker buildx build --check .` reports no warnings
- [ ] No `FileNotFoundError` on startup when `git` is absent