### PR TITLE
fix: get_version crash when git binary is absent

### DIFF
--- a/src/utils/mutils.py
+++ b/src/utils/mutils.py
@@ -31,7 +31,7 @@ def get_version():
             .strip()
         )
         return tag
-    except CalledProcessError:
+    except (CalledProcessError, OSError):
         try:
             sha = (
                 subprocess.check_output(
@@ -41,7 +41,7 @@ def get_version():
                 .strip()
             )
             return f"untagged-{sha}"
-        except CalledProcessError:
+        except (CalledProcessError, OSError):
             return "unknown"
 
 


### PR DESCRIPTION
Fixes #8.

## Problem

`get_version()` in `src/utils/mutils.py` calls `git describe --tags` via `subprocess.check_output`. When `git` is not installed (e.g. in a minimal Docker image or stripped-down deployment), Python raises `FileNotFoundError`. This exception is **not** caught by the existing `except CalledProcessError` handler, so the agent crashes at import time before any configuration is loaded.

## Change

Widen both `except` clauses in `get_version()` from `CalledProcessError` to `(CalledProcessError, OSError)`. `FileNotFoundError` is a subclass of `OSError`, so a missing `git` binary now falls through to `"unknown"` gracefully — matching the intent of the existing fallback chain.

```diff
-    except CalledProcessError:
+    except (CalledProcessError, OSError):
         try:
             sha = subprocess.check_output(
                 ["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.DEVNULL
             ).decode().strip()
             return f"untagged-{sha}"
-        except CalledProcessError:
+        except (CalledProcessError, OSError):
             return "unknown"
```

## Test plan

- [ ] Run `python agent.py --help` on a system without `git` — should print help without a traceback
- [ ] Run `python agent.py -d ...` on a system without `git` — agent starts, version reported as `"unknown"`
- [ ] Run `python agent.py -d ...` on a system with `git` — version still resolved from tags/commit as before